### PR TITLE
NetCDF static fix VERSION 2 (DRAFT)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,16 +31,11 @@ endif()
 
 option(OPENMP "use OpenMP threading" OFF)
 
-#find_package(
-#  HDF5
-#  COMPONENTS HL Fortran
-#  REQUIRED)
-#find_package(NetCDF REQUIRED COMPONENTS Fortran)
+find_package(NetCDF REQUIRED)
 find_package(MPI REQUIRED COMPONENTS Fortran)
 find_package(Jasper REQUIRED)
 find_package(PNG REQUIRED)
 find_package(ESMF MODULE REQUIRED)
-find_package(ZLIB REQUIRED)
 find_package(WGRIB2 REQUIRED)
 
 if(OPENMP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,11 @@ endif()
 
 option(OPENMP "use OpenMP threading" OFF)
 
-find_package(
-  HDF5
-  COMPONENTS HL Fortran
-  REQUIRED)
-find_package(NetCDF REQUIRED COMPONENTS Fortran)
+#find_package(
+#  HDF5
+#  COMPONENTS HL Fortran
+#  REQUIRED)
+#find_package(NetCDF REQUIRED COMPONENTS Fortran)
 find_package(MPI REQUIRED COMPONENTS Fortran)
 find_package(Jasper REQUIRED)
 find_package(PNG REQUIRED)

--- a/sorc/chgres_cube.fd/CMakeLists.txt
+++ b/sorc/chgres_cube.fd/CMakeLists.txt
@@ -28,8 +28,8 @@ endif()
 set(exe_name chgres_cube.exe)
 add_executable(${exe_name} ${fortran_src})
 target_include_directories(
-  ${exe_name} PRIVATE ${ESMF_INC} ${WGRIB2_INCLUDES}
-                      ${NETCDF_INCLUDES} ${NETCDF_INCLUDES_F90})
+  ${exe_name} PRIVATE ${ESMF_INC} ${WGRIB2_INCLUDES} ${NETCDF_INCLUDE_DIRS})
+
 target_link_libraries(
   ${exe_name}
   nemsio
@@ -41,10 +41,7 @@ target_link_libraries(
   esmf
   MPI::MPI_Fortran
   ${WGRIB2_LIBRARIES}
-  ${NETCDF_LIBRARIES_F90}
-  ${NETCDF_LIBRARIES}
-  ${HDF5_Fortran_HL_LIBRARIES}
-  ${HDF5_LIBRARIES})
+  ${NETCDF_LIBRARIES})
 if(OpenMP_Fortran_FOUND)
   target_link_libraries(${exe_name} OpenMP::OpenMP_Fortran)
 endif()


### PR DESCRIPTION
Update to use JEDI version of FindNetCDF.cmake (with minor modifications, see https://github.com/NOAA-EMC/CMakeModules/pull/28).